### PR TITLE
De la guardo setup clojure 34

### DIFF
--- a/.github/integration_test.sh
+++ b/.github/integration_test.sh
@@ -14,6 +14,7 @@ fi
 # add some debugging to verify CLI state:
 clojure -Sdescribe
 ls -l /home/runner/.config/clojure/
+ls -l /home/runner/.clojure/
 clojure -Ttool list
 
 if ! clojure -Ttools install nvd-clojure/nvd-clojure '{:mvn/version "RELEASE"}' :as nvd; then

--- a/.github/integration_test.sh
+++ b/.github/integration_test.sh
@@ -13,7 +13,10 @@ fi
 
 # add some debugging to verify CLI state:
 clojure -Sdescribe
+echo "Root deps"
 cat /opt/hostedtoolcache/ClojureToolsDeps/1.10.3-1029/x64/lib/clojure/deps.edn
+echo "User deps"
+cat /home/runner/.config/clojure/deps.edn
 clojure -Ttool list
 
 if ! clojure -Ttools install nvd-clojure/nvd-clojure '{:mvn/version "RELEASE"}' :as nvd; then

--- a/.github/integration_test.sh
+++ b/.github/integration_test.sh
@@ -12,8 +12,8 @@ if ! lein with-profile -user,-dev,+ci install; then
 fi
 
 # manually setup tools -- this should be auto-created:
-#mkdir /home/runner/.config/clojure/tools
-#echo '{:lib io.github.clojure/tools.tools :coord {:git/tag "v0.2.2" :git/sha "e1febed7ddaa5be15721255c13eb68e11bbbb398"}}' > /home/runner/.config/clojure/tools/tools.edn
+mkdir /home/runner/.config/clojure/tools
+echo '{:lib io.github.clojure/tools.tools :coord {:git/tag "v0.2.2" :git/sha "e1febed7ddaa5be15721255c13eb68e11bbbb398"}}' > /home/runner/.config/clojure/tools/tools.edn
 
 if ! clojure -Ttools install nvd-clojure/nvd-clojure '{:mvn/version "RELEASE"}' :as nvd; then
   exit 1

--- a/.github/integration_test.sh
+++ b/.github/integration_test.sh
@@ -11,6 +11,8 @@ if ! lein with-profile -user,-dev,+ci install; then
   exit 1
 fi
 
+# prep the CLI -- this should not be needed:
+clojure -P
 # manually setup tools -- this should be auto-created:
 mkdir /home/runner/.config/clojure/tools
 echo '{:lib io.github.clojure/tools.tools :coord {:git/tag "v0.2.2" :git/sha "e1febed7ddaa5be15721255c13eb68e11bbbb398"}}' > /home/runner/.config/clojure/tools/tools.edn

--- a/.github/integration_test.sh
+++ b/.github/integration_test.sh
@@ -11,6 +11,10 @@ if ! lein with-profile -user,-dev,+ci install; then
   exit 1
 fi
 
+# add some debugging to verify CLI state:
+clojure -Sdescribe
+clojure -Ttool list
+
 if ! clojure -Ttools install nvd-clojure/nvd-clojure '{:mvn/version "RELEASE"}' :as nvd; then
   exit 1
 fi

--- a/.github/integration_test.sh
+++ b/.github/integration_test.sh
@@ -13,6 +13,7 @@ fi
 
 # add some debugging to verify CLI state:
 clojure -Sdescribe
+ls -l /home/runner/.config/clojure/
 clojure -Ttool list
 
 if ! clojure -Ttools install nvd-clojure/nvd-clojure '{:mvn/version "RELEASE"}' :as nvd; then

--- a/.github/integration_test.sh
+++ b/.github/integration_test.sh
@@ -11,6 +11,10 @@ if ! lein with-profile -user,-dev,+ci install; then
   exit 1
 fi
 
+# fetch deps to initialize CLI:
+clojure -P
+ls -l /home/runner/.config/clojure/
+ls -l /home/runner/.config/clojure/tools/
 # manually setup tools -- this should be auto-created:
 mkdir /home/runner/.config/clojure/tools
 echo '{:lib io.github.clojure/tools.tools :coord {:git/tag "v0.2.2" :git/sha "e1febed7ddaa5be15721255c13eb68e11bbbb398"}}' > /home/runner/.config/clojure/tools/tools.edn

--- a/.github/integration_test.sh
+++ b/.github/integration_test.sh
@@ -15,6 +15,7 @@ fi
 clojure -Sdescribe
 ls -l /home/runner/.config/clojure/
 ls -l /home/runner/.clojure/
+clojure -Stree
 clojure -Ttool list
 
 if ! clojure -Ttools install nvd-clojure/nvd-clojure '{:mvn/version "RELEASE"}' :as nvd; then

--- a/.github/integration_test.sh
+++ b/.github/integration_test.sh
@@ -11,16 +11,8 @@ if ! lein with-profile -user,-dev,+ci install; then
   exit 1
 fi
 
-# more debugging:
-date
-ls -lR /opt/hostedtoolcache/ClojureToolsDeps/1.10.3-1029/x64/lib/clojure
-ls -lR /home/runner/.config/clojure
-
-# prep the CLI -- this should not be needed:
-clojure -P
-/home/runner/.config/clojure
 # manually setup tools -- this should be auto-created:
-mkdir /home/runner/.config/clojure/tools
+mkdir -p /home/runner/.config/clojure/tools
 echo '{:lib io.github.clojure/tools.tools :coord {:git/tag "v0.2.2" :git/sha "e1febed7ddaa5be15721255c13eb68e11bbbb398"}}' > /home/runner/.config/clojure/tools/tools.edn
 
 if ! clojure -Ttools install nvd-clojure/nvd-clojure '{:mvn/version "RELEASE"}' :as nvd; then

--- a/.github/integration_test.sh
+++ b/.github/integration_test.sh
@@ -11,18 +11,9 @@ if ! lein with-profile -user,-dev,+ci install; then
   exit 1
 fi
 
-# fetch deps to initialize CLI:
-mkdir -p /home/runner/.config/clojure/tools
-clojure -P
-# does this fail?
-clojure -Ttools list
-ls -l /home/runner/.config/clojure/
-ls -l /home/runner/.config/clojure/tools/
 # manually setup tools -- this should be auto-created:
 #mkdir /home/runner/.config/clojure/tools
 #echo '{:lib io.github.clojure/tools.tools :coord {:git/tag "v0.2.2" :git/sha "e1febed7ddaa5be15721255c13eb68e11bbbb398"}}' > /home/runner/.config/clojure/tools/tools.edn
-# does this fail?
-clojure -Ttools list
 
 if ! clojure -Ttools install nvd-clojure/nvd-clojure '{:mvn/version "RELEASE"}' :as nvd; then
   exit 1

--- a/.github/integration_test.sh
+++ b/.github/integration_test.sh
@@ -12,14 +12,15 @@ if ! lein with-profile -user,-dev,+ci install; then
 fi
 
 # fetch deps to initialize CLI:
+mkdir -p /home/runner/.config/clojure/tools
 clojure -P
 # does this fail?
 clojure -Ttools list
 ls -l /home/runner/.config/clojure/
 ls -l /home/runner/.config/clojure/tools/
 # manually setup tools -- this should be auto-created:
-mkdir /home/runner/.config/clojure/tools
-echo '{:lib io.github.clojure/tools.tools :coord {:git/tag "v0.2.2" :git/sha "e1febed7ddaa5be15721255c13eb68e11bbbb398"}}' > /home/runner/.config/clojure/tools/tools.edn
+#mkdir /home/runner/.config/clojure/tools
+#echo '{:lib io.github.clojure/tools.tools :coord {:git/tag "v0.2.2" :git/sha "e1febed7ddaa5be15721255c13eb68e11bbbb398"}}' > /home/runner/.config/clojure/tools/tools.edn
 # does this fail?
 clojure -Ttools list
 

--- a/.github/integration_test.sh
+++ b/.github/integration_test.sh
@@ -13,20 +13,22 @@ fi
 
 # fetch deps to initialize CLI:
 clojure -P
+# does this fail?
+clojure -Ttools list
 ls -l /home/runner/.config/clojure/
 ls -l /home/runner/.config/clojure/tools/
 # manually setup tools -- this should be auto-created:
 mkdir /home/runner/.config/clojure/tools
 echo '{:lib io.github.clojure/tools.tools :coord {:git/tag "v0.2.2" :git/sha "e1febed7ddaa5be15721255c13eb68e11bbbb398"}}' > /home/runner/.config/clojure/tools/tools.edn
-# this fails still -- not sure why:
-clojure -Ttool list
+# does this fail?
+clojure -Ttools list
 
 if ! clojure -Ttools install nvd-clojure/nvd-clojure '{:mvn/version "RELEASE"}' :as nvd; then
   exit 1
 fi
 
 # see if we can get a tool list now:
-clojure -Ttool list
+clojure -Ttools list
 
 cd "$PROJECT_DIR/plugin" || exit 1
 

--- a/.github/integration_test.sh
+++ b/.github/integration_test.sh
@@ -11,16 +11,18 @@ if ! lein with-profile -user,-dev,+ci install; then
   exit 1
 fi
 
-# add some debugging to verify CLI state:
-clojure -Sdescribe
-# manually setup tools:
+# manually setup tools -- this should be auto-created:
 mkdir /home/runner/.config/clojure/tools
 echo '{:lib io.github.clojure/tools.tools :coord {:git/tag "v0.2.2" :git/sha "e1febed7ddaa5be15721255c13eb68e11bbbb398"}}' > /home/runner/.config/clojure/tools/tools.edn
+# this fails still -- not sure why:
 clojure -Ttool list
 
 if ! clojure -Ttools install nvd-clojure/nvd-clojure '{:mvn/version "RELEASE"}' :as nvd; then
   exit 1
 fi
+
+# see if we can get a tool list now:
+clojure -Ttool list
 
 cd "$PROJECT_DIR/plugin" || exit 1
 

--- a/.github/integration_test.sh
+++ b/.github/integration_test.sh
@@ -13,9 +13,7 @@ fi
 
 # add some debugging to verify CLI state:
 clojure -Sdescribe
-ls -l /home/runner/.config/clojure/
-ls -l /home/runner/.clojure/
-clojure -Stree
+cat /opt/hostedtoolcache/ClojureToolsDeps/1.10.3-1029/x64/lib/clojure/deps.edn
 clojure -Ttool list
 
 if ! clojure -Ttools install nvd-clojure/nvd-clojure '{:mvn/version "RELEASE"}' :as nvd; then

--- a/.github/integration_test.sh
+++ b/.github/integration_test.sh
@@ -21,9 +21,6 @@ if ! clojure -Ttools install nvd-clojure/nvd-clojure '{:mvn/version "RELEASE"}' 
   exit 1
 fi
 
-# see if we can get a tool list now:
-clojure -Ttools list
-
 cd "$PROJECT_DIR/plugin" || exit 1
 
 if ! lein with-profile -user,-dev,+ci install; then

--- a/.github/integration_test.sh
+++ b/.github/integration_test.sh
@@ -11,8 +11,14 @@ if ! lein with-profile -user,-dev,+ci install; then
   exit 1
 fi
 
+# more debugging:
+date
+ls -lR /opt/hostedtoolcache/ClojureToolsDeps/1.10.3-1029/x64/lib/clojure
+ls -lR /home/runner/.config/clojure
+
 # prep the CLI -- this should not be needed:
 clojure -P
+/home/runner/.config/clojure
 # manually setup tools -- this should be auto-created:
 mkdir /home/runner/.config/clojure/tools
 echo '{:lib io.github.clojure/tools.tools :coord {:git/tag "v0.2.2" :git/sha "e1febed7ddaa5be15721255c13eb68e11bbbb398"}}' > /home/runner/.config/clojure/tools/tools.edn

--- a/.github/integration_test.sh
+++ b/.github/integration_test.sh
@@ -13,10 +13,9 @@ fi
 
 # add some debugging to verify CLI state:
 clojure -Sdescribe
-echo "Root deps"
-cat /opt/hostedtoolcache/ClojureToolsDeps/1.10.3-1029/x64/lib/clojure/deps.edn
-echo "User deps"
-cat /home/runner/.config/clojure/deps.edn
+# manually setup tools:
+mkdir /home/runner/.config/clojure/tools
+echo '{:lib io.github.clojure/tools.tools :coord {:git/tag "v0.2.2" :git/sha "e1febed7ddaa5be15721255c13eb68e11bbbb398"}}' > /home/runner/.config/clojure/tools/tools.edn
 clojure -Ttool list
 
 if ! clojure -Ttools install nvd-clojure/nvd-clojure '{:mvn/version "RELEASE"}' :as nvd; then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Install leiningen
         uses: DeLaGuardo/setup-clojure@master
         with:
-          lein: 2.9.4
-          cli: 1.10.3.933
+          cli: '1.10.3.933'
+          lein: '2.9.4'
       - run: shellcheck .github/*.sh
       - run: .github/integration_test.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Install leiningen
         uses: DeLaGuardo/setup-clojure@master
         with:
-          cli: '1.10.3.933'
+          cli: '1.10.3.1029'
           lein: '2.9.4'
       - run: shellcheck .github/*.sh
       - run: .github/integration_test.sh


### PR DESCRIPTION
Update CLI to 1.10.3.1029 for CI and manually install `tools.tools` so `clojure -Ttools` works.

This is a workaround for https://github.com/DeLaGuardo/setup-clojure/issues/34