### PR TITLE
remove workaround for tools.tools install

### DIFF
--- a/.github/integration_test.sh
+++ b/.github/integration_test.sh
@@ -11,10 +11,6 @@ if ! lein with-profile -user,-dev,+ci install; then
   exit 1
 fi
 
-# manually setup tools -- this should be auto-created:
-mkdir -p /home/runner/.config/clojure/tools
-echo '{:lib io.github.clojure/tools.tools :coord {:git/tag "v0.2.2" :git/sha "e1febed7ddaa5be15721255c13eb68e11bbbb398"}}' > /home/runner/.config/clojure/tools/tools.edn
-
 if ! clojure -Ttools install nvd-clojure/nvd-clojure '{:mvn/version "RELEASE"}' :as nvd; then
   exit 1
 fi


### PR DESCRIPTION
`setup-clojure` (master) has been updated to install the CLI using the regular Linux script so the integration test should be able to use `clojure -Ttools install` without the workaround.