### PR TITLE
Dogfooding integration test: add a suppression

### DIFF
--- a/.github/dogfooding_suppressions.xml
+++ b/.github/dogfooding_suppressions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  <!-- You can find examples in https://jeremylong.github.io/DependencyCheck/general/suppression.html -->
+  <suppress>
+    <filePath regex="true">.*\bh2-1\.4\.199\.jar</filePath>
+    <cve>CVE-2021-23463</cve>
+  </suppress>
+</suppressions>

--- a/.github/integration_test.sh
+++ b/.github/integration_test.sh
@@ -5,6 +5,7 @@ cd "${BASH_SOURCE%/*}/.." || exit 1
 
 PROJECT_DIR="$PWD"
 CONFIG_FILE="$PROJECT_DIR/.github/nvd-config.json"
+DOGFOODING_CONFIG_FILE="$PROJECT_DIR/.github/nvd-dogfooding-config.json"
 SUCCESS_REGEX="[1-9][0-9] vulnerabilities detected\. Severity: "
 
 if ! lein with-profile -user,-dev,+ci install; then
@@ -118,7 +119,7 @@ cd "$PROJECT_DIR" || exit 1
 
 own_classpath="$(lein with-profile -user,-dev,-test classpath)"
 
-if ! lein with-profile -user,-dev,+ci run -m nvd.task.check "" "$own_classpath"; then
+if ! lein with-profile -user,-dev,+ci run -m nvd.task.check "$DOGFOODING_CONFIG_FILE" "$own_classpath"; then
   echo "nvd-clojure did not pass dogfooding!"
   exit 1
 fi
@@ -131,7 +132,7 @@ plugin_classpath="$(lein with-profile -user,-dev,-test classpath)"
 
 cd "$PROJECT_DIR" || exit 1
 
-if ! lein with-profile -user,-dev,+ci run -m nvd.task.check "" "$plugin_classpath"; then
+if ! lein with-profile -user,-dev,+ci run -m nvd.task.check "$DOGFOODING_CONFIG_FILE" "$plugin_classpath"; then
   echo "lein-nvd did not pass dogfooding!"
   exit 1
 fi

--- a/.github/nvd-dogfooding-config.json
+++ b/.github/nvd-dogfooding-config.json
@@ -1,0 +1,2 @@
+{"delete-config?": false,
+ "nvd": {"suppression-file": ".github/dogfooding_suppressions.xml"}}


### PR DESCRIPTION
It doesn't look like https://github.com/jeremylong/DependencyCheck/issues/3894 can be immediately fixed.

Furthermore nvd is CI-time software, vulnerabilities cannot possibly affect production.