### PR TITLE
Calculate classpath using tools.deps and provide nvd-clojure as a regular -X function?

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -6,7 +6,8 @@
         org.slf4j/slf4j-simple {:mvn/version "2.0.7"}
         org.owasp/dependency-check-core {:mvn/version "8.4.0"}
         rm-hull/table {:mvn/version "0.7.1"}
-        trptcolin/versioneer {:mvn/version "0.2.0"}}
+        trptcolin/versioneer {:mvn/version "0.2.0"}
+        org.clojure/tools.deps {:mvn/version "0.18.1354"}}
  :mvn/repos {"central" {:url "https://repo1.maven.org/maven2/"}
              "clojars" {:url "https://repo.clojars.org/"}}
  :tools/usage {:ns-default nvd.task}


### PR DESCRIPTION
Hi @vemv (and others)

And thanks for a great project!

I'm wondering if it is worthwhile to support calculating the classpath using tools.deps, thus avoiding the need for an extra script.
With the changes in this pull request, adding the following alias to an existing project:

```clojure
:nvd-check      {:replace-deps  {nvd-clojure/nvd-clojure {:local/root "/home/ire/code/nvd-clojure"}} ; real version / change the path to a proper folder on your machine
                              :replace-paths []
                              :jvm-opts      ["-Dclojure.main.report=stderr" "-Dorg.slf4j.simpleLogger.log.org.apache.commons=error"]
                              :exec-fn       nvd.task/check} 
```

enables to execute the nvd check using simply `clojure -X:nvd-check`.

I've verified that the new code in `nvd.task` produces identical classpath to the output of `clojure -Spath`.

(There could of course be something else I've missed, I'm not a classpath and/or tools.deps expert or anything like that.)

What do you think?

Thanks and kind regards.