### PR TITLE
Fix NVD API token bug

### DIFF
--- a/.github/nvd-config.edn
+++ b/.github/nvd-config.edn
@@ -1,2 +1,3 @@
 {:suppression-file ".github/example_nvd_suppressions.xml"
+ :nvd-api {:key nil}
  :analyzer {:ossindex-warn-only-on-remote-errors true}}

--- a/.github/nvd-config.json
+++ b/.github/nvd-config.json
@@ -1,3 +1,4 @@
 {"delete-config?": false,
  "nvd": {"suppression-file": ".github/example_nvd_suppressions.xml",
+         "nvd-api": {"key": null},
          "analyzer": {"ossindex-warn-only-on-remote-errors": true}}}

--- a/.github/nvd-dogfooding-config.edn
+++ b/.github/nvd-dogfooding-config.edn
@@ -1,2 +1,3 @@
 {:suppression-file ".github/dogfooding_suppressions.xml"
+ :nvd-api {:key nil}
  :analyzer {:ossindex-warn-only-on-remote-errors true}}

--- a/.github/nvd-dogfooding-config.json
+++ b/.github/nvd-dogfooding-config.json
@@ -1,3 +1,4 @@
 {"delete-config?": false,
  "nvd": {"suppression-file": ".github/dogfooding_suppressions.xml",
+         "nvd-api": {"key": null},
          "analyzer": {"ossindex-warn-only-on-remote-errors": true}}}

--- a/.github/nvd-tool-config.edn
+++ b/.github/nvd-tool-config.edn
@@ -1,1 +1,2 @@
-{:analyzer {:ossindex-warn-only-on-remote-errors true}}
+{:nvd-api {:key nil}
+ :analyzer {:ossindex-warn-only-on-remote-errors true}}

--- a/.github/nvd-tool-config.json
+++ b/.github/nvd-tool-config.json
@@ -1,2 +1,3 @@
 {"delete-config?": false,
- "nvd": {"analyzer": {"ossindex-warn-only-on-remote-errors": true}}}
+ "nvd": {"nvd-api": {"key": null},
+         "analyzer": {"ossindex-warn-only-on-remote-errors": true}}}

--- a/src/nvd/config.clj
+++ b/src/nvd/config.clj
@@ -200,7 +200,7 @@ You can pass an empty string for an .edn file to be automatically created."
     (doseq [[prop path] string-mappings]
       (.setStringIfNotEmpty settings prop (str (get-in nvd-settings path))))
 
-    (when (= ::not-found (get-in nvd-settings [:nvd-api :key] ::not-found))
+    (when (nil? (get-in nvd-settings [:nvd-api :key]))
       (let [api-key (System/getenv "NVD_API_TOKEN")]
 
         (when (or (not api-key)

--- a/test/nvd/config_test.clj
+++ b/test/nvd/config_test.clj
@@ -48,7 +48,8 @@
   (is (= "fred/hello-world" (sut/app-name {:name "hello-world" :group "fred" :version "0.0.1"}))))
 
 (deftest check-with-config
-  (let [expected-suppression-filename "suppress.xml"]
+  (let [expected-suppression-filename "suppress.xml"
+        expected-nvd-api-key "dummy-api-key"]
     (try
       (sut/with-config [project "test/resources/opts.json"]
         (let [path (-> project (get-in [:nvd :data-directory]) io/file .getAbsolutePath)
@@ -73,7 +74,10 @@
               (pr-str {:expected-1 expected-1
                        :expected-2 expected-2
                        :actual path})))
-        (is (= (get-in project [:nvd :suppression-file]) expected-suppression-filename))
+        (is (= expected-suppression-filename
+               (get-in project [:nvd :suppression-file])))
+        (is (= expected-nvd-api-key
+               (get-in project [:nvd :nvd-api :key])))
         (is (false? (get-in project [:nvd :analyzer :assembly-enabled])))
         (is (true? (get-in project [:nvd :analyzer :cmake-enabled])))
         (is (not (nil? (get-in project [:engine]))))

--- a/test/resources/opts.json
+++ b/test/resources/opts.json
@@ -5,6 +5,9 @@
     "delete-config?": false,
     "exit-after-check": false,
     "nvd": {
+        "nvd-api": {
+            "key": "dummy-api-key"
+        },
         "analyzer": {
             "cmake-enabled": true
         },


### PR DESCRIPTION
Address the issue #173, in which the `NVD_API_TOKEN` variable does not work when the `:nvd-api :key` value is present but `nil` (which is the case with the default generated config file). I also verified that passing in the API key via the config file and as an env var both work by doing a local `make install` followed by a scan via clojure tools.

Side note: For some reason when I run the integration tests locally they fail on the dogfooding config steps, even before I made any changes. It may be something funky with my local environment.