### PR TITLE
Upgrade to the latest dependency-check-core version: 10.0.3

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
         clansi/clansi {:mvn/version "1.0.0"}
         org.clojure/data.json {:mvn/version "2.5.0"}
         org.slf4j/slf4j-simple {:mvn/version "2.0.10"}
-        org.owasp/dependency-check-core {:mvn/version "9.0.8"}
+        org.owasp/dependency-check-core {:mvn/version "10.0.3"}
         rm-hull/table {:mvn/version "0.7.1"}
         trptcolin/versioneer {:mvn/version "0.2.0"}}
  :mvn/repos {"central" {:url "https://repo1.maven.org/maven2/"}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nvd-clojure "4.0.0"
+(defproject nvd-clojure "4.0.1"
   :description "National Vulnerability Database dependency checker"
   :url "https://github.com/rm-hull/nvd-clojure"
   :license {:name "The MIT License (MIT)"
@@ -7,7 +7,7 @@
                  [clansi "1.0.0"]
                  [org.clojure/data.json "2.5.0"]
                  [org.slf4j/slf4j-simple "2.0.10"]
-                 [org.owasp/dependency-check-core "9.0.8"]
+                 [org.owasp/dependency-check-core "10.0.3"]
                  [rm-hull/table "0.7.1"]
                  [trptcolin/versioneer "0.2.0"]
                  ;; Explicitly depend on a certain Jackson, consistently.

--- a/test/nvd/config_test.clj
+++ b/test/nvd/config_test.clj
@@ -69,7 +69,8 @@
                               suffix-2)]
           (is (or (.endsWith path expected-1)
                   (.endsWith path expected-2)
-                  (.endsWith path "7.0")) ;; In recent releases, there's e.g. .../org/owasp/dependency-check-utils/8.0.2/data/7.0 which breaks the traditional match between versions
+                  (.endsWith path "9.0") ;; In recent releases, there's e.g. .../org/owasp/dependency-check-utils/8.0.2/data/7.0 which breaks the traditional match between versions
+                  (.endsWith path "7.0"))
               (pr-str {:expected-1 expected-1
                        :expected-2 expected-2
                        :actual path})))


### PR DESCRIPTION
 - Due to https://github.com/jeremylong/DependencyCheck/issues/6817 we need to uptake the mandatory upgrade to dependency-check-core 10.0.3 for the dependency check to work.