### PR TITLE
[gha] Install lein before running lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,11 +25,11 @@ jobs:
         uses: actions/checkout@master
         with:
           ref: ${{ github.ref }}
-      - run: .github/lint.sh
       - name: Install leiningen
         uses: DeLaGuardo/setup-clojure@master
         with:
           lein: 2.9.4
+      - run: .github/lint.sh
       - run: lein cljfmt check
       - run: lein with-profile +dev cloverage --lcov
       - name: Coveralls


### PR DESCRIPTION
The lint job requires lein.